### PR TITLE
MVP of a metrics client to track installs/uninstalls

### DIFF
--- a/lib/peek_app_sdk/metrics.ex
+++ b/lib/peek_app_sdk/metrics.ex
@@ -1,0 +1,5 @@
+defmodule PeekAppSdk.Metrics do
+  @moduledoc """
+  This module provides functions for tracking metrics to Ahem.
+  """
+end

--- a/lib/peek_app_sdk/metrics.ex
+++ b/lib/peek_app_sdk/metrics.ex
@@ -2,4 +2,17 @@ defmodule PeekAppSdk.Metrics do
   @moduledoc """
   This module provides functions for tracking metrics to Ahem.
   """
+
+  defdelegate track_install(external_refid, name, is_test), to: PeekAppSDK.Metrics.Client
+  defdelegate track_uninstall(external_refid, name, is_test), to: PeekAppSDK.Metrics.Client
+
+  defdelegate track_event(
+                external_refid,
+                name,
+                is_test,
+                event_id,
+                level \\ "info",
+                anonymous_id \\ nil
+              ),
+              to: PeekAppSDK.Metrics.Client
 end

--- a/lib/peek_app_sdk/metrics/client.ex
+++ b/lib/peek_app_sdk/metrics/client.ex
@@ -9,23 +9,6 @@ defmodule PeekAppSDK.Metrics.Client do
   plug Tesla.Middleware.Headers, [{"Content-Type", "application/json"}]
   plug Tesla.Middleware.Retry, delay: 500, max_retries: 10
 
-  defp event_url,
-    do: "https://ahem.peeklabs.com/events/#{Application.fetch_env!(:peek_app_sdk, :peek_app_id)}"
-
-  defp do_post!(body, _opts \\ []) do
-    response = post!(event_url(), body)
-
-    case response do
-      %Tesla.Env{status: 202} ->
-        :ok
-
-      %Tesla.Env{status: status, body: _body} ->
-        {:error, status}
-    end
-
-    {:ok, body}
-  end
-
   @doc """
   Tracks an app installation event.
 
@@ -124,5 +107,22 @@ defmodule PeekAppSDK.Metrics.Client do
       "partnerExternalRefid" => external_refid,
       "partnerIsTest" => is_test
     }
+  end
+
+  defp event_url,
+    do: "https://ahem.peeklabs.com/events/#{Application.fetch_env!(:peek_app_sdk, :peek_app_id)}"
+
+  defp do_post!(body, _opts \\ []) do
+    response = post!(event_url(), body)
+
+    case response do
+      %Tesla.Env{status: 202} ->
+        :ok
+
+      %Tesla.Env{status: status, body: _body} ->
+        {:error, status}
+    end
+
+    {:ok, body}
   end
 end

--- a/lib/peek_app_sdk/metrics/client.ex
+++ b/lib/peek_app_sdk/metrics/client.ex
@@ -1,0 +1,128 @@
+defmodule PeekAppSDK.Metrics.Client do
+  use Tesla
+
+  @moduledoc """
+  Client for sending metrics to the Peek Pro metrics service.
+  """
+
+  plug Tesla.Middleware.JSON
+  plug Tesla.Middleware.Headers, [{"Content-Type", "application/json"}]
+  plug Tesla.Middleware.Retry, delay: 500, max_retries: 10
+
+  defp event_url,
+    do: "https://ahem.peeklabs.com/events/#{Application.fetch_env!(:peek_app_sdk, :peek_app_id)}"
+
+  defp do_post!(body, _opts \\ []) do
+    response = post!(event_url(), body)
+
+    case response do
+      %Tesla.Env{status: 202} ->
+        :ok
+
+      %Tesla.Env{status: status, body: _body} ->
+        {:error, status}
+    end
+
+    {:ok, body}
+  end
+
+  @doc """
+  Tracks an app installation event.
+
+  ## Parameters
+
+    * `external_refid` - The external reference ID for the partner
+    * `name` - The name of the partner
+    * `is_test` - Boolean indicating if this is a test installation
+
+  ## Examples
+
+      iex> PeekAppSDK.Metrics.Client.track_install("partner-123", "Partner Name", false)
+      {:ok, %{...}}
+
+  """
+  def track_install(external_refid, name, is_test) do
+    usage_display = if is_test, do: "New TEST App Installs", else: "New App Installs"
+
+    do_post!(%{
+      eventId: "app.install",
+      level: "info",
+      anonymousId: external_refid,
+      usageDisplay: usage_display,
+      usageDetails: name,
+      postMessage: "#{name} installed",
+      customFields: base_custom_fields(name, external_refid, is_test)
+    })
+  end
+
+  @doc """
+  Tracks an app uninstallation event.
+
+  ## Parameters
+
+    * `external_refid` - The external reference ID for the partner
+    * `name` - The name of the partner
+    * `is_test` - Boolean indicating if this is a test installation
+
+  ## Examples
+
+      iex> PeekAppSDK.Metrics.Client.track_uninstall("partner-123", "Partner Name", false)
+      {:ok, %{...}}
+
+  """
+  def track_uninstall(external_refid, name, is_test) do
+    usage_display = if is_test, do: "New TEST App Uninstalls", else: "New App Uninstalls"
+
+    do_post!(%{
+      eventId: "app.uninstall",
+      level: "info",
+      anonymousId: external_refid,
+      usageDisplay: usage_display,
+      usageDetails: name,
+      postMessage: "#{name} uninstalled",
+      customFields: base_custom_fields(name, external_refid, is_test)
+    })
+  end
+
+  @doc """
+  Tracks a custom event.
+
+  ## Parameters
+
+    * `external_refid` - The external reference ID for the partner
+    * `name` - The name of the partner
+    * `is_test` - Boolean indicating if this is a test installation
+    * `event_id` - The ID of the event to track
+    * `level` - The level of the event (default: "info")
+    * `anonymous_id` - Optional anonymous ID to use instead of external_refid
+
+  ## Examples
+
+      iex> PeekAppSDK.Metrics.Client.track_event("partner-123", "Partner Name", false, "custom.event")
+      {:ok, %{...}}
+
+  """
+  def track_event(
+        external_refid,
+        name,
+        is_test,
+        event_id,
+        level \\ "info",
+        anonymous_id \\ nil
+      ) do
+    do_post!(%{
+      eventId: event_id,
+      level: level,
+      anonymousId: anonymous_id || external_refid,
+      customFields: base_custom_fields(name, external_refid, is_test)
+    })
+  end
+
+  defp base_custom_fields(name, external_refid, is_test) do
+    %{
+      "partnerName" => name,
+      "partnerExternalRefid" => external_refid,
+      "partnerIsTest" => is_test
+    }
+  end
+end

--- a/lib/peek_app_sdk/ui/core_components.ex
+++ b/lib/peek_app_sdk/ui/core_components.ex
@@ -226,7 +226,12 @@ defmodule PeekAppSDK.UI.CoreComponents do
   attr(:type, :string, default: nil)
   attr(:class, :string, default: nil)
   attr(:rest, :global, include: ~w(disabled form name value))
-  attr(:button_type, :string, default: "primary", values: ["primary", "secondary", "info", "danger"])
+
+  attr(:button_type, :string,
+    default: "primary",
+    values: ["primary", "secondary", "info", "danger"]
+  )
+
   attr(:disabled, :boolean, default: false)
   attr(:id, :string, default: nil)
 

--- a/test/peek_app_sdk/metrics/client_test.exs
+++ b/test/peek_app_sdk/metrics/client_test.exs
@@ -1,0 +1,179 @@
+defmodule PeekAppSDK.Metrics.ClientTest do
+  use ExUnit.Case, async: true
+  import Mox
+
+  alias PeekAppSDK.Metrics.Client
+
+  setup :verify_on_exit!
+
+  describe "track_install/3" do
+    test "sends correct payload for regular installation" do
+      external_refid = "partner-123"
+      name = "Partner Name"
+      is_test = false
+
+      expect(PeekAppSDK.MockTeslaClient, :call, fn env, _opts ->
+        assert env.method == :post
+        assert String.contains?(env.url, "ahem.peeklabs.com/events/")
+
+        payload = Jason.decode!(env.body)
+        assert payload["eventId"] == "app.install"
+        assert payload["level"] == "info"
+        assert payload["anonymousId"] == external_refid
+        assert payload["usageDisplay"] == "New App Installs"
+        assert payload["usageDetails"] == name
+        assert payload["postMessage"] == "#{name} installed"
+
+        assert payload["customFields"] == %{
+                 "partnerName" => name,
+                 "partnerExternalRefid" => external_refid,
+                 "partnerIsTest" => is_test
+               }
+
+        {:ok, %Tesla.Env{status: 202}}
+      end)
+
+      assert {:ok, _} = Client.track_install(external_refid, name, is_test)
+    end
+
+    test "sends correct payload for test installation" do
+      external_refid = "partner-test-123"
+      name = "Test Partner"
+      is_test = true
+
+      expect(PeekAppSDK.MockTeslaClient, :call, fn env, _opts ->
+        assert env.method == :post
+
+        payload = Jason.decode!(env.body)
+        assert payload["eventId"] == "app.install"
+        assert payload["usageDisplay"] == "New TEST App Installs"
+        assert payload["customFields"]["partnerIsTest"] == true
+
+        {:ok, %Tesla.Env{status: 202}}
+      end)
+
+      assert {:ok, _} = Client.track_install(external_refid, name, is_test)
+    end
+  end
+
+  describe "track_uninstall/3" do
+    test "sends correct payload for regular uninstallation" do
+      external_refid = "partner-123"
+      name = "Partner Name"
+      is_test = false
+
+      expect(PeekAppSDK.MockTeslaClient, :call, fn env, _opts ->
+        assert env.method == :post
+
+        payload = Jason.decode!(env.body)
+        assert payload["eventId"] == "app.uninstall"
+        assert payload["level"] == "info"
+        assert payload["anonymousId"] == external_refid
+        assert payload["usageDisplay"] == "New App Uninstalls"
+        assert payload["usageDetails"] == name
+        assert payload["postMessage"] == "#{name} uninstalled"
+
+        assert payload["customFields"] == %{
+                 "partnerName" => name,
+                 "partnerExternalRefid" => external_refid,
+                 "partnerIsTest" => is_test
+               }
+
+        {:ok, %Tesla.Env{status: 202}}
+      end)
+
+      assert {:ok, _} = Client.track_uninstall(external_refid, name, is_test)
+    end
+
+    test "sends correct payload for test uninstallation" do
+      external_refid = "partner-test-123"
+      name = "Test Partner"
+      is_test = true
+
+      expect(PeekAppSDK.MockTeslaClient, :call, fn env, _opts ->
+        assert env.method == :post
+
+        payload = Jason.decode!(env.body)
+        assert payload["eventId"] == "app.uninstall"
+        assert payload["usageDisplay"] == "New TEST App Uninstalls"
+        assert payload["customFields"]["partnerIsTest"] == true
+
+        {:ok, %Tesla.Env{status: 202}}
+      end)
+
+      assert {:ok, _} = Client.track_uninstall(external_refid, name, is_test)
+    end
+  end
+
+  describe "track_event/6" do
+    test "sends correct payload for custom event" do
+      external_refid = "partner-123"
+      name = "Partner Name"
+      is_test = false
+      event_id = "custom.event"
+      level = "info"
+
+      expect(PeekAppSDK.MockTeslaClient, :call, fn env, _opts ->
+        assert env.method == :post
+
+        payload = Jason.decode!(env.body)
+        assert payload["eventId"] == event_id
+        assert payload["level"] == level
+        assert payload["anonymousId"] == external_refid
+
+        assert payload["customFields"] == %{
+                 "partnerName" => name,
+                 "partnerExternalRefid" => external_refid,
+                 "partnerIsTest" => is_test
+               }
+
+        {:ok, %Tesla.Env{status: 202}}
+      end)
+
+      assert {:ok, _} = Client.track_event(external_refid, name, is_test, event_id)
+    end
+
+    test "uses custom anonymous_id when provided" do
+      external_refid = "partner-123"
+      name = "Partner Name"
+      is_test = false
+      event_id = "custom.event"
+      level = "debug"
+      anonymous_id = "custom-id-123"
+
+      expect(PeekAppSDK.MockTeslaClient, :call, fn env, _opts ->
+        assert env.method == :post
+
+        payload = Jason.decode!(env.body)
+        assert payload["eventId"] == event_id
+        assert payload["level"] == level
+        # Should use the custom ID
+        assert payload["anonymousId"] == anonymous_id
+
+        {:ok, %Tesla.Env{status: 202}}
+      end)
+
+      assert {:ok, _} =
+               Client.track_event(external_refid, name, is_test, event_id, level, anonymous_id)
+    end
+
+    test "uses custom level when provided" do
+      external_refid = "partner-123"
+      name = "Partner Name"
+      is_test = false
+      event_id = "custom.event"
+      level = "error"
+
+      expect(PeekAppSDK.MockTeslaClient, :call, fn env, _opts ->
+        assert env.method == :post
+
+        payload = Jason.decode!(env.body)
+        assert payload["level"] == level
+
+        {:ok, %Tesla.Env{status: 202}}
+      end)
+
+      assert {:ok, _} = Client.track_event(external_refid, name, is_test, event_id, level)
+    end
+  end
+end


### PR DESCRIPTION
Allows for:

```
  defp on_uninstalled(partner) do
    Client.track_uninstall(partner.external_refid, partner.name, partner.is_test)
  end
```

In the example repo and result in:

<img width="1218" alt="image" src="https://github.com/user-attachments/assets/8b5050e3-7d66-40fe-95ec-dda8b4d9370a" />

Inside https://ahem.peeklabs.com/admin/apps/5a0ceb3a-888a-4307-98cd-a594e9770069