### PR TITLE
feat: expose verified JWT claims as peek_verified_claims conn assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-04-27]
+
+### Added
+
+- `AccountUser` now includes a `locale` field (optional `String.t()`), extracted from the `"locale"` key in the JWT user claims.
+- `PeekAuth` plug now assigns `peek_verified_claims` on the conn — the full verified JWT claims map — giving LiveViews and controllers direct access to raw claim data without re-parsing the token.
+
 ## [2026-03-23]
 
 ### Added

--- a/lib/peek_app_sdk/account_user.ex
+++ b/lib/peek_app_sdk/account_user.ex
@@ -2,22 +2,16 @@ defmodule PeekAppSDK.AccountUser do
   @moduledoc """
   When iFrames are loaded, who is the logged in user?
   """
-  @fields [
-    :email,
-    :id,
-    :is_peek_admin,
-    :name,
-    :primary_role
-  ]
-  @enforce_keys @fields
-  defstruct @fields
+  @enforce_keys [:email, :id, :is_peek_admin, :name, :primary_role]
+  defstruct [:email, :id, :is_peek_admin, :name, :primary_role, locale: nil]
 
   @type t :: %__MODULE__{
           email: String.t(),
           id: String.t(),
           is_peek_admin: boolean(),
           name: String.t(),
-          primary_role: String.t()
+          primary_role: String.t() | nil,
+          locale: String.t() | nil
         }
 
   @doc """

--- a/lib/peek_app_sdk/plugs/peek_auth.ex
+++ b/lib/peek_app_sdk/plugs/peek_auth.ex
@@ -56,6 +56,7 @@ defmodule PeekAppSDK.Plugs.PeekAuth do
         |> assign(:peek_install_id, install_id)
         |> assign(:peek_account_user, build_account_user(claims))
         |> assign(:peek_config_id, config_id)
+        |> assign(:peek_verified_claims, claims)
 
       _ ->
         conn

--- a/lib/peek_app_sdk/plugs/peek_auth.ex
+++ b/lib/peek_app_sdk/plugs/peek_auth.ex
@@ -80,19 +80,21 @@ defmodule PeekAppSDK.Plugs.PeekAuth do
   end
 
   defp build_account_user(%{
-         "user" => %{
-           "id" => current_user_id,
-           "email" => current_user_email,
-           "is_admin" => current_user_is_peek_admin,
-           "name" => current_user_name
-         }
+         "user" =>
+           %{
+             "id" => current_user_id,
+             "email" => current_user_email,
+             "is_admin" => current_user_is_peek_admin,
+             "name" => current_user_name
+           } = user
        }) do
     %PeekAppSDK.AccountUser{
       email: current_user_email,
       id: current_user_id,
       is_peek_admin: current_user_is_peek_admin,
       name: current_user_name,
-      primary_role: nil
+      primary_role: nil,
+      locale: user["locale"]
     }
   end
 

--- a/test/peek_app_sdk/account_user_test.exs
+++ b/test/peek_app_sdk/account_user_test.exs
@@ -13,6 +13,7 @@ defmodule PeekAppSDK.AccountUserTest do
       assert hook.id == nil
       assert hook.is_peek_admin == nil
       assert hook.primary_role == nil
+      assert hook.locale == nil
     end
   end
 end

--- a/test/peek_app_sdk/plugs/peek_auth_test.exs
+++ b/test/peek_app_sdk/plugs/peek_auth_test.exs
@@ -216,6 +216,35 @@ defmodule PeekAppSDK.Plugs.PeekAuthTest do
       assert conn.assigns.peek_account_user.is_peek_admin == true
       assert conn.assigns.peek_account_user.name == "Legacy User"
       assert conn.assigns.peek_account_user.primary_role == nil
+      assert conn.assigns.peek_account_user.locale == nil
+    end
+
+    test "extracts locale from user JWT claims into account_user" do
+      install_id = "test_install_id"
+
+      config = PeekAppSDK.Config.get_config()
+      shared_secret_key = config.peek_app_secret
+      signer = Joken.Signer.create("HS256", shared_secret_key)
+
+      params = %{
+        "iss" => "app_registry_v2",
+        "sub" => install_id,
+        "exp" => DateTime.utc_now() |> DateTime.add(60) |> DateTime.to_unix(),
+        "user" => %{
+          "email" => "user@example.com",
+          "id" => "user123",
+          "is_admin" => false,
+          "name" => "Test User",
+          "locale" => "fr"
+        }
+      }
+
+      {:ok, token, _claims} = Token.generate_and_sign(params, signer)
+      conn = conn(:post, "/", %{"peek-auth" => token})
+
+      conn = PeekAuth.set_peek_install_id(conn, %{})
+
+      assert conn.assigns.peek_account_user.locale == "fr"
     end
 
     test "handles non-keyword list and non-map options" do

--- a/test/peek_app_sdk/plugs/peek_auth_test.exs
+++ b/test/peek_app_sdk/plugs/peek_auth_test.exs
@@ -27,6 +27,8 @@ defmodule PeekAppSDK.Plugs.PeekAuthTest do
       assert conn.assigns.peek_install_id == install_id
       assert conn.assigns.peek_install_token == token
       assert conn.assigns.peek_config_id == nil
+      assert is_map(conn.assigns.peek_verified_claims)
+      assert conn.assigns.peek_verified_claims["sub"] == install_id
 
       # Don't test session in tests since it's not properly initialized
       # and we're now handling that gracefully in the implementation


### PR DESCRIPTION
## Summary

- After `verify_peek_auth` succeeds, the full decoded claims map is now assigned to `conn.assigns[:peek_verified_claims]`
- Downstream apps can read any claim (e.g. `locale`) without re-verifying the token or manually decoding the JWT payload

## Why

Previously the claims were built into `peek_account_user` and then discarded. Apps that need fields not modelled on `AccountUser` (e.g. `locale`, future fields) had no clean way to access them — they either had to re-call `verify_peek_auth` (double verification) or base64-decode the raw `peek_install_token` themselves.

## Usage

```elixir
# In any plug/controller that runs after set_peek_install_id:
locale = get_in(conn.assigns, [:peek_verified_claims, "locale"])
```

## Test plan

- [x] Existing tests pass
- [x] New assertion verifies `peek_verified_claims` is set with correct `sub` claim